### PR TITLE
Set initial content after TinyMCE finishes initialization

### DIFF
--- a/TinyMce.vue
+++ b/TinyMce.vue
@@ -39,6 +39,8 @@ export default {
       editor.on('Change', (e) => {
         this.$emit('input', editor.getContent());
       });
+      
+      editor.setContent(this.value);
     },
     ...this.otherProps
   })


### PR DESCRIPTION
In case TinyMCE loads after the rest of the page (or after data arrives, etc…), the content doesn't appear in the editor. The line I added fixes that as proposed here: https://stackoverflow.com/a/20410580/1762862 .